### PR TITLE
cut inv

### DIFF
--- a/main/strings.ijs
+++ b/main/strings.ijs
@@ -75,7 +75,7 @@ NB.*ljust v left justify
 NB.*rjust v right justify
 NB.*ss v string search
 
-cut=: ' '&$: :([: -.&a: <;._2@,~)
+cut=: ' '&$: :([:-.&a:<;._2@,~) :.(;:inv@] : [:)
 deb=: #~ (+. 1: |. (> </\))@(' '&~:)
 debc=: #~"1 [: (+. (1: |. (> </\))) ' '&(+./ .~:)
 delstring=: 4 : ';(x E.r) <@((#x)&}.) ;.1 r=. x,y'


### PR DESCRIPTION
Use ;:inv as cut's monadic obverse

It would be nice if we could define this obverse to be sensitive to cut's optional left argument, but I currently do not see how to accomplish that.  So... leave obverse for the dyadic case as a domain error to allow for possible future enhancement.